### PR TITLE
Refresh token endpoint.

### DIFF
--- a/app/Http/Controllers/JWTAuthController.php
+++ b/app/Http/Controllers/JWTAuthController.php
@@ -67,4 +67,13 @@ class JWTAuthController extends Controller
         // if no errors are encountered we can return a JWT
         return response()->json(compact('token'));
     }
+
+    public function refreshToken()
+    {
+        $token = JWTAuth::refresh(JWTAuth::getToken());
+        if (! $token) {
+            return response()->json(['error' => 'invalid_credentials'], 401);
+        }
+        return response()->json(['token' => $token], 200);
+    }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -31,5 +31,6 @@ Route::group(['prefix' => 'api', 'middleware' => ['throttle']], function()
 {
 	Route::resource('authenticate', 'JWTAuthController', ['only' => ['index']]);
 	Route::post('authenticate', 'JWTAuthController@authenticate');
+	Route::get('refresh-token', 'JWTAuthController@refreshToken');
     Route::resource('send', 'Api\SendController', ['only' => ['store']]);
 });

--- a/tests/Controllers/Api/SendControllerTest.php
+++ b/tests/Controllers/Api/SendControllerTest.php
@@ -31,9 +31,9 @@ class SendControllerTest extends TestCase
         $response = $this->call('POST', 'api/authenticate', $data);
         $content = json_decode($response->getContent());
         $token = $content->token;
-        $headers = array(
+        $headers = [
             'Authorization' => 'Bearer ' . $token
-        );
+        ];
         // accessing JWTAuthController@index
         $this->json('GET', '/api/authenticate', [], $headers)
             ->seeJsonStructure([

--- a/tests/Controllers/AuthControllerTest.php
+++ b/tests/Controllers/AuthControllerTest.php
@@ -14,14 +14,7 @@ class AuthControllerTest extends TestCase
      */
     public function auth()
     {
-        $user = $this->createUser();
-        $monitor = $this->createMonitor($user);
-
-        $data = [
-            'api_key' => $user->api_key,
-            'monitor_key' => $monitor->monitor_key,
-        ];
-        $response = $this->call('POST', 'api/authenticate', $data);
+        $response = $this->postAuth();
         $this->assertResponseStatus(200);
         $content = json_decode($response->getContent());
         $this->assertTrue(array_key_exists('token', $content));
@@ -36,7 +29,45 @@ class AuthControllerTest extends TestCase
             'api_key' => '00000000-ffff-0000-ffff-000000000000',
             'monitor_key' => '00000000-ffff-0000-ffff-000000000000',
         ];
-        $response = $this->call('POST', 'api/authenticate', $data);
+        $response = $this->call('POST', '/api/authenticate', $data);
         $this->assertResponseStatus(401);
+    }
+
+    /**
+     * @test
+     */
+    public function refreshToken()
+    {
+        $response = $this->postAuth();
+        $this->assertResponseStatus(200);
+        $content = json_decode($response->getContent());
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $content->token
+        ];
+
+        // refresh token, expect a new one
+        $this->json('GET', 'api/refresh-token', [], $headers)
+            ->seeJsonStructure([
+                'token'
+            ]);
+
+        // using the first token, is not valid anymore
+        $this->json('GET', 'api/refresh-token', [], $headers)
+            ->seeJsonEquals([
+                "error" => "token_invalid"
+            ]);
+    }
+
+    private function postAuth()
+    {
+        $user = $this->createUser();
+        $monitor = $this->createMonitor($user);
+
+        $data = [
+            'api_key' => $user->api_key,
+            'monitor_key' => $monitor->monitor_key,
+        ];
+        return $this->call('POST', '/api/authenticate', $data);
     }
 }


### PR DESCRIPTION
Desenvolvedor pode solicitar novo token baseado no que já possui,
assim pode renovar token para continuar realizando requisições.

Para isso basta dar um GET no endpoint /api/refresh-token enviando
o token como parâmetro ou Header Authorization.

Fixed #58.