### PR TITLE
Opção de editar Monitor, salvando em formato JSON apropriado.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ php artisan serve
 
 ### With code coverage option
 
-`php vendor/bin/phpunit --coverage-html _reports/coverage/``
+`php vendor/bin/phpunit --coverage-html _reports/coverage/`
 
 ## License
 

--- a/app/Http/Controllers/AbstractMonitorController.php
+++ b/app/Http/Controllers/AbstractMonitorController.php
@@ -5,8 +5,9 @@ namespace App\Http\Controllers;
 use App\Monitor;
 use Webpatser\Uuid\Uuid;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
-class AbstractMonitorController extends Controller
+abstract class AbstractMonitorController extends Controller
 {
     public function __construct()
     {
@@ -20,10 +21,40 @@ class AbstractMonitorController extends Controller
      */
     protected function _save($result)
     {
+        unset($result['_token']);
+        if (isset($result['id']) && $result['id'] > 0) {
+            $id = $result['id'];
+            unset($result['id']);
+            return Monitor::where('id', $id)
+                ->where('user_id', Auth::user()->id)
+                ->update(['data' => json_encode($result)]);
+        }
         return Monitor::create([
             'monitor_key' => Uuid::generate(4),
-            'data' => json_encode($result),
+            'data' => $result,
             'user_id' => Auth::user()->id,
         ]);
     }
+
+    protected function _getMonitor($id, $user = -1) {
+        if ($user == -1) {
+            $user = Auth::user();
+        }
+        $monitor = DB::table('monitors')
+                    ->join('users', 'monitors.user_id', '=', 'users.id')
+                    ->select('monitors.*')
+                    ->where([
+                        ['monitors.id', '=', $id],
+                        ['users.id', '=', $user->id]
+                    ])->get();
+        return Monitor::hydrate($monitor)[0];
+    }
+
+    /**
+     * Transforms the JSON data from Monitor into
+     * a dynamic Monitor.
+     * @param  Monitor $monitor
+     * @return Monitor
+     */
+    abstract protected function transformJson(Monitor $monitor);
 }

--- a/app/Http/Controllers/Api/SendController.php
+++ b/app/Http/Controllers/Api/SendController.php
@@ -35,8 +35,8 @@ class SendController extends Controller
                 ]
             ], 400);
         }
-        $monitor_data = json_decode($monitor->data);
-        $type = $monitor_data->type;
+
+        $type = $monitor->data['type'];
         $json_schema_file = "json-schema/{$type}.json";
         if (! Storage::exists($json_schema_file)) {
             return response()->json([

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -31,14 +31,12 @@ class MonitorController extends Controller
             ->orderBy('updated_at', 'desc')
             ->get()
             ->toArray();
-        $items = Monitor::hydrate($list);
-        return response()->json(['ok' => true, 'list' => $items]);
+        return response()->json(['ok' => true, 'list' => $list]);
     }
 
     public function show($id) {
         $user = Auth::user();
         $monitor = $this->get($id, $user);
-        $monitor->data = json_decode($monitor->data, TRUE);
         $auth_json = "{
   \"api_key\": \"{$user->api_key}\",
   \"monitor_key\": \"{$monitor->monitor_key}\"
@@ -65,7 +63,6 @@ class MonitorController extends Controller
         $user = Auth::user();
         $id = $request->input('id');
         $monitor = $this->get($id, $user);
-        $monitor->data = json_decode($monitor->data, TRUE);
         return response()->json(['monitor' => $monitor, 'ok' => true]);
     }
 

--- a/package-template/src/Http/Controllers/PluginController.php
+++ b/package-template/src/Http/Controllers/PluginController.php
@@ -4,13 +4,18 @@ namespace @@Vendor\@@Plugin\Http\Controllers;
 
 use App\Http\Controllers\AbstractMonitorController;
 use Illuminate\Http\Request;
+use App\Monitor;
 
 class @@PluginController extends AbstractMonitorController
 {
     public function create()
     {
         $title = 'New @@Plugin Monitor';
-        return view('@@plugin::save', ['title' => $title]);
+        $model = null;
+        return view('@@plugin::save', [
+            'title' => $title,
+            'model' => $model,
+        ]);
     }
 
     public function store(Request $request)
@@ -23,5 +28,24 @@ class @@PluginController extends AbstractMonitorController
         $result['type'] = '@@plugin';
         $this->_save($result);
         return redirect('/monitor');
+    }
+
+    public function edit($id)
+    {
+        $monitor = $this->_getMonitor($id);
+        $title = 'Edit @@Plugin Monitor';
+
+        return view('@@plugin::save', [
+            'title' => $title,
+            'model' => $this->transformJson($monitor),
+        ]);
+    }
+
+    protected function transformJson(Monitor $monitor)
+    {
+        $obj = new Monitor();
+        $obj->id = $monitor->id;
+        // fill the object
+        return $obj;
     }
 }

--- a/package-template/src/assets/templates/plugin/index.mustache
+++ b/package-template/src/assets/templates/plugin/index.mustache
@@ -7,7 +7,11 @@
         <div class="box-body">
         </div>
         <div class="box-footer">
-            <div class="pull-right">
+            <div class="btn-group pull-right">
+                <a href="/@@plugin/{{id}}/edit" class="btn btn-default btn-sm">
+                    <i class="fa fa-edit"></i>
+                    Edit
+                </a>
                 <a href="/monitor/{{id}}" class="btn btn-default btn-sm">
                     <i class="fa fa-chevron-right"></i>
                     View

--- a/package-template/src/views/save.blade.php
+++ b/package-template/src/views/save.blade.php
@@ -11,9 +11,11 @@
 <div class="row">
     <div class="col-md-8 col-md-offset-2">
         {!! BootForm::open([
-            'model' => null,
-            'store' => '\@@Vendor\@@Plugin\Http\Controllers\@@PluginController@store'
+            'model' => $model,
+            'store' => '\@@Vendor\@@Plugin\Http\Controllers\@@PluginController@store',
+            'update' => '\@@Vendor\@@Plugin\Http\Controllers\@@PluginController@update',
         ]) !!}
+        {!! BootForm::hidden('id') !!}
         <div class="row">
             <div class="col-md-12">
                 {!! BootForm::text('description') !!}

--- a/packages/fidias/blinkleds/src/Http/Controllers/BlinkledsController.php
+++ b/packages/fidias/blinkleds/src/Http/Controllers/BlinkledsController.php
@@ -4,30 +4,39 @@ namespace Fidias\Blinkleds\Http\Controllers;
 
 use App\Http\Controllers\AbstractMonitorController;
 use Illuminate\Http\Request;
+use App\Monitor;
 
 class BlinkledsController extends AbstractMonitorController
 {
+    protected $colors = [
+        '#3498db' => 'blue',
+        '#18bc9c' => 'green',
+        '#f39c12' => 'orange',
+        '#e74c3c' => 'red',
+        '#9b59b6' => 'violet',
+        '#ecf0f1' => 'white',
+        '#f1c40f' => 'yellow'
+    ];
+
+    protected $rules = [
+        'description' => 'required|max:255',
+        'leds.*.id' => 'required|max:25',
+    ];
+
     public function create()
     {
         $title = 'New Blink LEDs Monitor';
-        $colors = [
-            '#3498db' => 'blue',
-            '#18bc9c' => 'green',
-            '#f39c12' => 'orange',
-            '#e74c3c' => 'red',
-            '#9b59b6' => 'violet',
-            '#ecf0f1' => 'white',
-            '#f1c40f' => 'yellow'
-        ];
-        return view('blinkleds::save', ['title' => $title, 'colors' => $colors]);
+        $model = null;
+        return view('blinkleds::save', [
+            'title' => $title,
+            'model' => $model,
+            'colors' => $this->colors
+        ]);
     }
 
     public function store(Request $request)
     {
-        $this->validate($request, [
-            'description' => 'required|max:255',
-            'leds.*.id' => 'required|max:25',
-        ], [
+        $this->validate($request, $this->rules, [
             'leds.*.id.required' => 'The LED field is required.',
             'leds.*.id.max' => 'The LED field may not be greater than :max characters.'
         ]);
@@ -36,5 +45,31 @@ class BlinkledsController extends AbstractMonitorController
         $result['type'] = 'blinkleds';
         $this->_save($result);
         return redirect('/monitor');
+    }
+
+    public function edit($id)
+    {
+        $monitor = $this->_getMonitor($id);
+        $title = 'Edit Blink LEDs Monitor';
+
+        return view('blinkleds::save', [
+            'title' => $title,
+            'colors' => $this->colors,
+            'model' => $this->transformJson($monitor),
+        ]);
+    }
+
+    /**
+     * Create dynamic monitor based on the JSON data.
+     * @param  Monitor $monitor
+     * @return Monitor
+     */
+    protected function transformJson(Monitor $monitor)
+    {
+        $obj = new Monitor();
+        $obj->id = $monitor->id;
+        $obj->description = $monitor->data['description'];
+        $obj->leds = $monitor->data['leds'];
+        return $obj;
     }
 }

--- a/packages/fidias/blinkleds/src/assets/templates/blinkleds/index.mustache
+++ b/packages/fidias/blinkleds/src/assets/templates/blinkleds/index.mustache
@@ -13,7 +13,11 @@
             </div>
         </div>
         <div class="box-footer">
-            <div class="pull-right">
+            <div class="btn-group pull-right">
+                <a href="/blinkleds/{{id}}/edit" class="btn btn-default btn-sm">
+                    <i class="fa fa-edit"></i>
+                    Edit
+                </a>
                 <a href="/monitor/{{id}}" class="btn btn-default btn-sm">
                     <i class="fa fa-chevron-right"></i>
                     View

--- a/packages/fidias/blinkleds/src/views/save.blade.php
+++ b/packages/fidias/blinkleds/src/views/save.blade.php
@@ -15,9 +15,11 @@
 <div class="row">
     <div class="col-md-8 col-md-offset-2">
         {!! BootForm::open([
-            'model' => null,
-            'store' => '\Fidias\Blinkleds\Http\Controllers\BlinkledsController@store'
+            'model' => $model,
+            'store' => '\Fidias\Blinkleds\Http\Controllers\BlinkledsController@store',
+            'update' => '\Fidias\Blinkleds\Http\Controllers\BlinkledsController@update',
         ]) !!}
+        {!! BootForm::hidden('id') !!}
         <div class="row">
             <div class="col-md-12">
                 {!! BootForm::text('description') !!}
@@ -42,10 +44,21 @@
 
         <div class="row">
             <div class="col-md-12" id="led-list">
-                @if(Form::old('leds'))
-                    @foreach(Form::old('leds') as $key => $val)
+                @php
+                    $leds = null;
+                    // priority to old leds, that represents
+                    // already edited information!
+                    if (Form::old('leds')) {
+                        $leds = Form::old('leds');
+                    } else if (! is_null($model)) {
+                        $leds = $model->leds;
+                    }
+                @endphp
+
+                @if($leds)
+                    @foreach($leds as $key => $val)
                         <div class="row led--item" id="led-item-{{$key}}">
-                            <div class="col-md-3" id="led-item-{{$key}}">
+                            <div class="col-md-3">
                                 {!! BootForm::text("leds[${key}][id]", "LED ${key}") !!}
                             </div>
                             <div class="col-md-3">

--- a/packages/fidias/photoresitor/src/Http/Controllers/PhotoresistorController.php
+++ b/packages/fidias/photoresitor/src/Http/Controllers/PhotoresistorController.php
@@ -4,26 +4,59 @@ namespace Fidias\Photoresistor\Http\Controllers;
 
 use App\Http\Controllers\AbstractMonitorController;
 use Illuminate\Http\Request;
+use App\Monitor;
 
 class PhotoresistorController extends AbstractMonitorController
 {
+    protected $rules = [
+        'description' => 'required|max:255',
+        'min' => 'required|numeric',
+        'max' => 'required|numeric',
+    ];
+
     public function create()
     {
         $title = 'New Photoresistor Monitor';
-        return view('photoresistor::save', ['title' => $title]);
+        $model = null;
+        return view('photoresistor::save', [
+            'title' => $title,
+            'model' => $model,
+        ]);
     }
 
     public function store(Request $request)
     {
-        $this->validate($request, [
-            'description' => 'required|max:255',
-            'min' => 'required|numeric',
-            'max' => 'required|numeric',
-        ]);
+        $this->validate($request, $this->rules);
 
         $result = $request->toArray();
         $result['type'] = 'photoresistor';
         $this->_save($result);
         return redirect('/monitor');
+    }
+
+    public function edit($id)
+    {
+        $monitor = $this->_getMonitor($id);
+        $title = 'Edit Photoresistor Monitor';
+
+        return view('photoresistor::save', [
+            'title' => $title,
+            'model' => $this->transformJson($monitor),
+        ]);
+    }
+
+    /**
+     * Create dynamic monitor based on the JSON data.
+     * @param  Monitor $monitor
+     * @return Monitor
+     */
+    protected function transformJson(Monitor $monitor)
+    {
+        $obj = new Monitor();
+        $obj->id = $monitor->id;
+        $obj->description = $monitor->data['description'];
+        $obj->min = $monitor->data['min'];
+        $obj->max = $monitor->data['max'];
+        return $obj;
     }
 }

--- a/packages/fidias/photoresitor/src/assets/templates/photoresistor/index.mustache
+++ b/packages/fidias/photoresitor/src/assets/templates/photoresistor/index.mustache
@@ -13,7 +13,11 @@
             </div>
         </div>
         <div class="box-footer">
-            <div class="pull-right">
+            <div class="btn-group pull-right">
+                <a href="/photoresistor/{{id}}/edit" class="btn btn-default btn-sm">
+                    <i class="fa fa-edit"></i>
+                    Edit
+                </a>
                 <a href="/monitor/{{id}}" class="btn btn-default btn-sm">
                     <i class="fa fa-chevron-right"></i>
                     View

--- a/packages/fidias/photoresitor/src/views/save.blade.php
+++ b/packages/fidias/photoresitor/src/views/save.blade.php
@@ -11,9 +11,11 @@
 <div class="row">
     <div class="col-md-8 col-md-offset-2">
         {!! BootForm::open([
-            'model' => null,
-            'store' => '\Fidias\Photoresistor\Http\Controllers\PhotoresistorController@store'
+            'model' => $model,
+            'store' => '\Fidias\Photoresistor\Http\Controllers\PhotoresistorController@store',
+            'update' => '\Fidias\Photoresistor\Http\Controllers\PhotoresistorController@update'
         ]) !!}
+        {!! BootForm::hidden('id') !!}
         <div class="row">
             <div class="col-md-12">
                 {!! BootForm::text('description') !!}

--- a/packages/fidias/temperature/src/Http/Controllers/TemperatureController.php
+++ b/packages/fidias/temperature/src/Http/Controllers/TemperatureController.php
@@ -4,37 +4,70 @@ namespace Fidias\Temperature\Http\Controllers;
 
 use App\Http\Controllers\AbstractMonitorController;
 use Illuminate\Http\Request;
+use App\Monitor;
 
 class TemperatureController extends AbstractMonitorController
 {
+    protected $rules = [
+        'description' => 'required|max:255',
+        'min' => 'required|numeric',
+        'max' => 'required|numeric',
+        'unit' => 'required',
+    ];
+
+    protected $units = [
+        'celcius' => 'Celcius',
+        'fahrenheit' => 'Fahrenheit',
+        'kelvin' => 'Kelvin'
+    ];
+
     public function create()
     {
         $title = 'New Temperature Monitor';
         $model = null;
-        $units = [
-            'celcius' => 'Celcius',
-            'fahrenheit' => 'Fahrenheit',
-            'kelvin' => 'Kelvin'
-        ];
+
         return view('temperature::save', [
-            'model' => $model,
-            'units' => $units,
             'title' => $title,
+            'model' => $model,
+            'units' => $this->units,
         ]);
     }
 
     public function store(Request $request)
     {
-        $this->validate($request, [
-            'description' => 'required|max:255',
-            'min' => 'required|numeric',
-            'max' => 'required|numeric',
-            'unit' => 'required',
-        ]);
+        $this->validate($request, $this->rules);
 
         $result = $request->toArray();
         $result['type'] = 'temperature';
         $this->_save($result);
         return redirect('/monitor');
+    }
+
+    public function edit($id)
+    {
+        $monitor = $this->_getMonitor($id);
+        $title = 'Edit Temperature Monitor';
+
+        return view('temperature::save', [
+            'title' => $title,
+            'units' => $this->units,
+            'model' => $this->transformJson($monitor),
+        ]);
+    }
+
+    /**
+     * Create dynamic monitor based on the JSON data.
+     * @param  Monitor $monitor
+     * @return Monitor
+     */
+    protected function transformJson(Monitor $monitor)
+    {
+        $obj = new Monitor();
+        $obj->id = $monitor->id;
+        $obj->description = $monitor->data['description'];
+        $obj->min = $monitor->data['min'];
+        $obj->max = $monitor->data['max'];
+        $obj->unit = $monitor->data['unit'];
+        return $obj;
     }
 }

--- a/packages/fidias/temperature/src/assets/templates/temperature/index.mustache
+++ b/packages/fidias/temperature/src/assets/templates/temperature/index.mustache
@@ -13,7 +13,11 @@
             </div>
         </div>
         <div class="box-footer">
-            <div class="pull-right">
+            <div class="btn-group pull-right">
+                <a href="/temperature/{{id}}/edit" class="btn btn-default btn-sm">
+                    <i class="fa fa-edit"></i>
+                    Edit
+                </a>
                 <a href="/monitor/{{id}}" class="btn btn-default btn-sm">
                     <i class="fa fa-chevron-right"></i>
                     View

--- a/packages/fidias/temperature/src/views/save.blade.php
+++ b/packages/fidias/temperature/src/views/save.blade.php
@@ -12,8 +12,10 @@
     <div class="col-md-8 col-md-offset-2">
         {!! BootForm::open([
             'model' => $model,
-            'store' => '\Fidias\Temperature\Http\Controllers\TemperatureController@store'
+            'store' => '\Fidias\Temperature\Http\Controllers\TemperatureController@store',
+            'update' => '\Fidias\Temperature\Http\Controllers\TemperatureController@update'
         ]) !!}
+        {!! BootForm::hidden('id') !!}
         <div class="row">
             <div class="col-md-12">
                 {!! BootForm::text('description') !!}

--- a/tests/Controllers/MonitorControllerTest.php
+++ b/tests/Controllers/MonitorControllerTest.php
@@ -40,7 +40,6 @@ class MonitorControllerTest extends TestCase
         $monitor = $this->createMonitor($user);
         $this->actingAs($user);
         $response = $this->call('GET', "/monitor/{$monitor->id}");
-        file_put_contents('/tmp/index.html', $response->content());
         $this->assertEquals(200, $response->status());
         $this->assertViewHas('monitor');
         $this->assertViewHas('auth_json');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,7 +43,10 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $monitor = factory(Monitor::class)->create([
             'monitor_key' => Uuid::generate(4),
             'user_id' => $user->id,
-            'data' => '{"value": 10, "type": "' . $type . '"}',
+            'data' => [
+                'value' => 10,
+                'type' => $type,
+            ]
         ]);
         return $monitor;
     }


### PR DESCRIPTION
Antes os dados do monitor (salvos na coluna data) estavam sendo
guardados como String e não como objeto JSON propriamente dito.
Isso causava a necessidade da chamada do método json_decode do
PHP em vários trechos do código.

Essa alteração invalida qualquer monitor salvo previamente, devendo o
banco ser resetado ou ser feito um script para conversão correta dos
dados.

A edição é feita a partir do objeto JSON, criando um objeto dinâmico do
tipo App\Monitor, em que são injetados os dados.

Atualização do template para novo plugin com os dados para editar plugin.

This fixes #68, fixes #50.